### PR TITLE
Small docs fix for in-browser code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Available color names:
 ```html
 <script src="https://unpkg.com/badgen"></script>
 <script>
-  var svgString = badgen.badgen({ /*...*/ })
+  var svgString = badgen({ /*...*/ })
 </script>
 ```
 


### PR DESCRIPTION
when i threw together a codepen to test badgen using the in-browser code sample, i found that the `badgen` function was directly on the `window` global (i.e. `window.badgen`, not `window.badgen.badgen`)